### PR TITLE
feat: return core.NotFoundError if no such key

### DIFF
--- a/go/pkg/ncraft/storage/minio/minio.go
+++ b/go/pkg/ncraft/storage/minio/minio.go
@@ -79,6 +79,10 @@ func (m *Minio) Read(key string, options core.Options) (*storage.Object, error) 
 
     info, err := obj.Stat()
     if err != nil {
+        errResponse := &minio.ErrorResponse{}
+        if errors.As(err, errResponse) && errResponse.Code == "NoSuchKey" {
+            return nil, core.NewNotFoundError("failed to found the key %s", key)
+        }
         return nil, err
     }
     object := &storage.Object{


### PR DESCRIPTION
修正minio读取不存在的key时，没有返回core.NotFoundError的问题